### PR TITLE
Fix UnicodeDecodeError on Windows by specifying utf-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as infile:
+with open('README.rst', encoding='utf-8') as infile:
     readme = infile.read()
 
-with open('lazy_import/VERSION') as infile:
+with open('lazy_import/VERSION', encoding='utf-8') as infile:
     version = infile.read().strip()
 
 tests_require = ['pytest', 'pytest-xdist']


### PR DESCRIPTION
**Problem**
On Windows systems (where the default encoding is often GBK or CP1252), installing this package fails with a UnicodeDecodeError because `setup.py` attempts to read `README.rst` and `VERSION` without specifying an encoding. Python then uses the system default encoding, which cannot decode the UTF-8 characters in those files.

Error Message:
```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa5 in position 623: illegal multibyte sequence
```

**Solution**
I explicitly added encoding='utf-8' to the open() calls in `setup.py`. This ensures that the files are correctly read as UTF-8 regardless of the operating system's default encoding settings.

**Verification**
Verified that `pip install .` works correctly on Windows after this change.